### PR TITLE
Expose requested host

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -131,6 +131,18 @@ class Request
     }
 
     /**
+     * Returns the host requested by the client
+     *
+     * @psalm-mutation-free
+     *
+     * @return non-empty-string Requested host
+     */
+    public function getHost(): string
+    {
+        return $this->url->domain;
+    }
+
+    /**
      * Returns the URL path of this request
      *
      * @psalm-mutation-free

--- a/tests/Request/RequestTest.php
+++ b/tests/Request/RequestTest.php
@@ -60,7 +60,11 @@ final class RequestTest extends TestCase
         self::assertSame('http', $this->request->getProtocol());
     }
 
-    
+    public function testCanGetHost(): void
+    {
+        self::assertSame('localhost', $this->request->getHost());
+    }
+
     public function testCanGetRequestedPath(): void
     {
         self::assertSame('/resource/sub-resource', $this->request->getPath());
@@ -135,6 +139,7 @@ final class RequestTest extends TestCase
 
         self::assertSame('POST', $request->getMethod());
         self::assertSame('https', $request->getProtocol());
+        self::assertSame('example.com', $request->getHost());
         self::assertSame('/account/delete', $request->getPath());
         self::assertTrue($request->isSecure());
         self::assertTrue($request->isKnownMethod());


### PR DESCRIPTION
Minor addition to the `Request` class:
- Add `getHost` method to expose request `host` value